### PR TITLE
Update and rename LDDS75 decoder--Chirpstack.txt to LDDS75 v1.2 decod…

### DIFF
--- a/LDDS75/LDDS75 v1.2 decoder--Chirpstack V4.txt
+++ b/LDDS75/LDDS75 v1.2 decoder--Chirpstack V4.txt
@@ -6,7 +6,7 @@ function Decode(fPort, bytes, variables) {
   var batV=value/1000;//Battery,units:V
   
   var distance = 0;
-  if(len==5)  
+  if(len==8)  
   {
    value=bytes[2]<<8 | bytes[3];
    distance=(value);//distance,units:mm


### PR DESCRIPTION
…er--Chirpstack V4.txt

Line 9 
if(len= ) was 5 now 8

To fix 'No Sensor' fault in Chirpstack V4 when running LDDS75 FW V1.2