### PR TITLE
Update and rename LDDS75 decoder--TTN.txt to LDDS75 v1.2 decoder--TTN…

### DIFF
--- a/LDDS75/LDDS75 v1.2 decoder--TTN V3.txt
+++ b/LDDS75/LDDS75 v1.2 decoder--TTN V3.txt
@@ -6,7 +6,7 @@ function Decoder(bytes, port) {
   var batV=value/1000;//Battery,units:V
   
   var distance = 0;
-  if(len==5)  
+  if(len==8)  
   {
    value=bytes[2]<<8 | bytes[3];
    distance=(value);//distance,units:mm


### PR DESCRIPTION
… V3.txt

Len value conflicts with the decoder in TTN. 

Len = 8 is required for the decoder to function

File naming convention adjusted to clarify SW versions